### PR TITLE
feat: Add translation features

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -275,6 +275,9 @@ dependencies {
     // Logging
     implementation(libs.logcat)
 
+    // ML Kit
+    implementation(libs.bundles.mlkit)
+
     // Shizuku
     implementation(libs.bundles.shizuku)
 

--- a/app/src.main/java/eu/kanade/presentation/more/settings/screen/SettingsTranslationsScreen.kt
+++ b/app/src.main/java/eu/kanade/presentation/more/settings/screen/SettingsTranslationsScreen.kt
@@ -1,0 +1,124 @@
+
+package eu.kanade.presentation.more.settings.screen
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Translate
+import dev.icerock.moko.resources.StringResource
+import eu.kanade.presentation.util.Screen
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.i18n.stringResource
+import eu.kanade.presentation.more.settings.Preference
+import tachiyomi.domain.library.service.LibraryPreferences
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import tachiyomi.presentation.core.components.material.Scaffold
+import androidx.compose.material3.TopAppBar
+import eu.kanade.presentation.components.AppBar
+import eu.kanade.presentation.components.AppBarActions
+import kotlinx.collections.immutable.persistentListOf
+import tachiyomi.presentation.core.screen.DeviceScreenSpec
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+
+object SettingsTranslationsScreen : Screen() {
+
+    @Composable
+    override fun Content() {
+        val navigator = LocalNavigator.currentOrThrow
+        val libraryPreferences = remember { Injekt.get<LibraryPreferences>() }
+        val scope = rememberCoroutineScope()
+
+        Scaffold(
+            topBar = { scrollBehavior ->
+                AppBar(
+                    title = stringResource(MR.strings.pref_category_translations),
+                    navigateUp = navigator::pop,
+                    scrollBehavior = scrollBehavior,
+                )
+            },
+            content = { contentPadding ->
+                val downloadNewChapters by libraryPreferences.downloadNewChapters().collectAsState()
+                val items = remember(downloadNewChapters) {
+                    listOf(
+                        Preference.PreferenceGroup(
+                            title = stringResource(MR.strings.pref_category_translations),
+                            preferenceItems = listOf(
+                                Preference.PreferenceItem.Switch(
+                                    pref = libraryPreferences.translateOnDownload(),
+                                    title = stringResource(MR.strings.pref_enable_translations),
+                                ),
+                                Preference.PreferenceItem.ListPreference(
+                                    pref = libraryPreferences.translateFrom(),
+                                    title = stringResource(MR.strings.pref_translate_from),
+                                    entries = mapOf(
+                                        "en" to "English or latin script",
+                                        "zh" to "Chinese",
+                                        "ja" to "Japanese",
+                                        "ko" to "Korean",
+                                    ),
+                                ),
+                                Preference.PreferenceItem.ListPreference(
+                                    pref = libraryPreferences.translateTo(),
+                                    title = stringResource(MR.strings.pref_translate_to),
+                                    entries = mapOf(
+                                        "af" to "Afrikaans",
+                                        "sq" to "Albanian",
+                                        "ca" to "Catalan",
+                                        "zh" to "Chinese",
+                                        "hr" to "Croatian",
+                                        "cs" to "Czech",
+                                        "da" to "Danish",
+                                        "nl" to "Dutch",
+                                        "en" to "English",
+                                        "et" to "Estonian",
+                                        "fi" to "Filipino",
+                                        "fr" to "Finnish",
+                                        "de" to "German",
+                                        "hu" to "Hungarian",
+                                        "is" to "Icelandic",
+                                        "id" to "Indonesian",
+                                        "it" to "Italian",
+                                        "ja" to "Japanese",
+                                        "ko" to "Korean",
+                                        "lv" to "Latvian",
+                                        "lt" to "Lithuanian",
+                                        "ms" to "Malay",
+                                        "no" to "Norwegian",
+                                        "pl" to "Polish",
+                                        "pt" to "Portuguese",
+                                        "ro" to "Romanian",
+                                        "sr" to "Serbian (Latin)",
+                                        "sk" to "Slovak",
+                                        "sl" to "Slovenian",
+                                        "es" to "Spanish",
+                                        "sv" to "Swedish",
+                                        "tr" to "Turkish",
+                                        "vi" to "Vietnamese",
+                                    ),
+                                ),
+                                Preference.PreferenceItem.ListPreference(
+                                    pref = libraryPreferences.translateEngine(),
+                                    title = stringResource(MR.strings.pref_translate_engine),
+                                    entries = mapOf(
+                                        "ml-kit" to "ML-Kit",
+                                        "google-translate" to "Google Translate",
+                                    ),
+                                ),
+                            ),
+                        ),
+                    )
+                }
+                PreferenceScreen(
+                    items = items,
+                    contentPadding = contentPadding,
+                )
+            }
+        )
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -61,6 +61,7 @@ import eu.kanade.presentation.util.formatChapterNumber
 import eu.kanade.tachiyomi.data.download.model.Download
 import eu.kanade.tachiyomi.source.getNameForMangaInfo
 import eu.kanade.tachiyomi.ui.manga.ChapterList
+import eu.kanade.tachiyomi.data.translation.model.Translation
 import eu.kanade.tachiyomi.ui.manga.MangaScreenModel
 import eu.kanade.tachiyomi.util.system.copyToClipboard
 import tachiyomi.domain.chapter.model.Chapter
@@ -790,6 +791,7 @@ private fun LazyListScope.sharedChapterItems(
                     downloadIndicatorEnabled = !isAnyChapterSelected && !manga.isLocal(),
                     downloadStateProvider = { item.downloadState },
                     downloadProgressProvider = { item.downloadProgress },
+                    translationStateProvider = { Translation.State.NOT_TRANSLATED },
                     chapterSwipeStartAction = chapterSwipeStartAction,
                     chapterSwipeEndAction = chapterSwipeEndAction,
                     onLongClick = {
@@ -809,6 +811,7 @@ private fun LazyListScope.sharedChapterItems(
                     } else {
                         null
                     },
+                    onTranslateClick = { /* TODO */ },
                     onChapterSwipe = {
                         onChapterSwipe(item, it)
                     },

--- a/app/src/main/java/eu/kanade/presentation/manga/components/ChapterTranslationIndicator.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/ChapterTranslationIndicator.kt
@@ -1,0 +1,39 @@
+
+package eu.kanade.presentation.manga.components
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Translate
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import eu.kanade.tachiyomi.data.translation.model.Translation
+import tachiyomi.presentation.core.components.material.IconToggleButton
+
+@Composable
+fun ChapterTranslationIndicator(
+    enabled: Boolean,
+    translationStateProvider: () -> Translation.State,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (enabled) {
+        val state = translationStateProvider()
+        val icon = when (state) {
+            Translation.State.NOT_TRANSLATED -> Icons.Outlined.Translate
+            Translation.State.TRANSLATING -> Icons.Outlined.Translate // TODO: Add a loading indicator
+            Translation.State.TRANSLATED -> Icons.Outlined.Translate // TODO: Add a checkmark icon
+        }
+        IconToggleButton(
+            checked = false,
+            onCheckedChange = { onClick() },
+            modifier = modifier.padding(start = 4.dp),
+            icon = {
+                androidx.compose.material3.Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                )
+            },
+        )
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaChapterListItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaChapterListItem.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import eu.kanade.tachiyomi.data.download.model.Download
+import eu.kanade.tachiyomi.data.translation.model.Translation
 import me.saket.swipe.SwipeableActionsBox
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.i18n.MR
@@ -57,11 +58,13 @@ fun MangaChapterListItem(
     downloadIndicatorEnabled: Boolean,
     downloadStateProvider: () -> Download.State,
     downloadProgressProvider: () -> Int,
+    translationStateProvider: () -> Translation.State,
     chapterSwipeStartAction: LibraryPreferences.ChapterSwipeAction,
     chapterSwipeEndAction: LibraryPreferences.ChapterSwipeAction,
     onLongClick: () -> Unit,
     onClick: () -> Unit,
     onDownloadClick: ((ChapterDownloadAction) -> Unit)?,
+    onTranslateClick: (() -> Unit)?,
     onChapterSwipe: (LibraryPreferences.ChapterSwipeAction) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -177,6 +180,13 @@ fun MangaChapterListItem(
                 downloadStateProvider = downloadStateProvider,
                 downloadProgressProvider = downloadProgressProvider,
                 onClick = { onDownloadClick?.invoke(it) },
+            )
+
+            ChapterTranslationIndicator(
+                enabled = downloadStateProvider() == Download.State.DOWNLOADED,
+                modifier = Modifier.padding(start = 4.dp),
+                translationStateProvider = translationStateProvider,
+                onClick = { onTranslateClick?.invoke() },
             )
         }
     }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsMainScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsMainScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Security
 import androidx.compose.material.icons.outlined.Storage
 import androidx.compose.material.icons.outlined.Sync
+import androidx.compose.material.icons.outlined.Translate
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TopAppBarDefaults
@@ -195,6 +196,12 @@ object SettingsMainScreen : Screen() {
             subtitleRes = MR.strings.pref_downloads_summary,
             icon = Icons.Outlined.GetApp,
             screen = SettingsDownloadScreen,
+        ),
+        Item(
+            titleRes = MR.strings.pref_category_translations,
+            subtitleRes = MR.strings.pref_translations_summary,
+            icon = Icons.Outlined.Translate,
+            screen = SettingsTranslationsScreen,
         ),
         Item(
             titleRes = MR.strings.pref_category_tracking,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTranslationsScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTranslationsScreen.kt
@@ -1,0 +1,19 @@
+
+package eu.kanade.presentation.more.settings.screen
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Translate
+import dev.icerock.moko.resources.StringResource
+import eu.kanade.presentation.util.Screen
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.i18n.stringResource
+
+object SettingsTranslationsScreen : Screen() {
+
+    @Composable
+    override fun Content() {
+        // TODO: Implement the UI for the Translations settings page.
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/GeneralSettingsPage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/GeneralSettingsPage.kt
@@ -92,6 +92,11 @@ internal fun ColumnScope.GeneralPage(screenModel: ReaderSettingsScreenModel) {
     )
 
     CheckboxItem(
+        label = stringResource(MR.strings.pref_show_translations),
+        pref = screenModel.preferences.showTranslations(),
+    )
+
+    CheckboxItem(
         label = stringResource(MR.strings.pref_flash_page),
         pref = screenModel.preferences.flashOnPageChange(),
     )

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/TranslationManager.kt
@@ -1,0 +1,60 @@
+
+package eu.kanade.tachiyomi.data.translation
+
+import android.content.Context
+import com.google.mlkit.common.model.DownloadConditions
+import com.google.mlkit.nl.translate.TranslateLanguage
+import com.google.mlkit.nl.translate.Translation
+import com.google.mlkit.nl.translate.TranslatorOptions
+import eu.kanade.tachiyomi.data.translation.model.TranslationCache
+import tachiyomi.core.common.util.system.logcat
+import uy.kohesive.injekt.injectLazy
+import java.io.File
+
+class TranslationManager(
+    private val context: Context,
+) {
+
+    private val cache = TranslationCache(context)
+
+    fun getTranslator(from: String, to: String) {
+        val options = TranslatorOptions.Builder()
+            .setSourceLanguage(from)
+            .setTargetLanguage(to)
+            .build()
+        val translator = Translation.getClient(options)
+        val conditions = DownloadConditions.Builder()
+            .requireWifi()
+            .build()
+        translator.downloadModelIfNeeded(conditions)
+            .addOnSuccessListener {
+                logcat { "Translator model downloaded" }
+            }
+            .addOnFailureListener {
+                logcat(it) { "Failed to download translator model" }
+            }
+    }
+
+    fun translate(text: String, from: String, to: String, onResult: (String) -> Unit) {
+        val options = TranslatorOptions.Builder()
+            .setSourceLanguage(from)
+            .setTargetLanguage(to)
+            .build()
+        val translator = Translation.getClient(options)
+        translator.translate(text)
+            .addOnSuccessListener {
+                onResult(it)
+            }
+            .addOnFailureListener {
+                logcat(it) { "Failed to translate text" }
+            }
+    }
+
+    fun getFromCache(pageId: Long): String? {
+        return cache.get(pageId)
+    }
+
+    fun putInCache(pageId: Long, translation: String) {
+        cache.put(pageId, translation)
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/model/Translation.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/model/Translation.kt
@@ -1,0 +1,13 @@
+
+package eu.kanade.tachiyomi.data.translation.model
+
+data class Translation(
+    val chapterId: Long,
+    val state: State,
+) {
+    enum class State {
+        NOT_TRANSLATED,
+        TRANSLATING,
+        TRANSLATED,
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/translation/model/TranslationCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/translation/model/TranslationCache.kt
@@ -1,0 +1,32 @@
+
+package eu.kanade.tachiyomi.data.translation.model
+
+import android.content.Context
+import java.io.File
+
+class TranslationCache(
+    private val context: Context,
+) {
+
+    private val cacheDir = File(context.cacheDir, "translations")
+
+    init {
+        if (!cacheDir.exists()) {
+            cacheDir.mkdirs()
+        }
+    }
+
+    fun get(pageId: Long): String? {
+        val file = File(cacheDir, pageId.toString())
+        return if (file.exists()) {
+            file.readText()
+        } else {
+            null
+        }
+    }
+
+    fun put(pageId: Long, translation: String) {
+        val file = File(cacheDir, pageId.toString())
+        file.writeText(translation)
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -57,6 +57,7 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.coil.TachiyomiImageDecoder
 import eu.kanade.tachiyomi.data.notification.NotificationReceiver
 import eu.kanade.tachiyomi.data.notification.Notifications
+import eu.kanade.tachiyomi.data.translation.TranslationManager
 import eu.kanade.tachiyomi.databinding.ReaderActivityBinding
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.ui.base.activity.BaseActivity
@@ -119,6 +120,7 @@ class ReaderActivity : BaseActivity() {
     lateinit var binding: ReaderActivityBinding
 
     val viewModel by viewModels<ReaderViewModel>()
+    private val translationManager by lazy { TranslationManager(applicationContext) }
     private var assistUrl: String? = null
 
     private val hasCutout by lazy { hasDisplayCutout() }
@@ -525,7 +527,7 @@ class ReaderActivity : BaseActivity() {
      */
     private fun updateViewer() {
         val prevViewer = viewModel.state.value.viewer
-        val newViewer = ReadingMode.toViewer(viewModel.getMangaReadingMode(), this)
+        val newViewer = ReadingMode.toViewer(viewModel.getMangaReadingMode(), this, translationManager)
 
         if (window.sharedElementEnterTransition is MaterialContainerTransform) {
             // Wait until transition is complete to avoid crash on API 26

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -77,6 +77,8 @@ class ReaderPreferences(
 
     fun webtoonDisableZoomOut() = preferenceStore.getBoolean("webtoon_disable_zoom_out", false)
 
+    fun showTranslations() = preferenceStore.getBoolean("show_translations", false)
+
     // endregion
 
     // region Split two page spread

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReadingMode.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReadingMode.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.ui.reader.setting
 import androidx.annotation.DrawableRes
 import dev.icerock.moko.resources.StringResource
 import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.data.translation.TranslationManager
 import eu.kanade.tachiyomi.ui.reader.ReaderActivity
 import eu.kanade.tachiyomi.ui.reader.viewer.Viewer
 import eu.kanade.tachiyomi.ui.reader.viewer.pager.L2RPagerViewer
@@ -66,11 +67,11 @@ enum class ReadingMode(
             return mode.type is ViewerType.Pager
         }
 
-        fun toViewer(preference: Int?, activity: ReaderActivity): Viewer {
+        fun toViewer(preference: Int?, activity: ReaderActivity, translationManager: TranslationManager): Viewer {
             return when (fromPreference(preference)) {
-                LEFT_TO_RIGHT -> L2RPagerViewer(activity)
-                RIGHT_TO_LEFT -> R2LPagerViewer(activity)
-                VERTICAL -> VerticalPagerViewer(activity)
+                LEFT_TO_RIGHT -> L2RPagerViewer(activity, translationManager)
+                RIGHT_TO_LEFT -> R2LPagerViewer(activity, translationManager)
+                VERTICAL -> VerticalPagerViewer(activity, translationManager)
                 WEBTOON -> WebtoonViewer(activity)
                 CONTINUOUS_VERTICAL -> WebtoonViewer(activity, isContinuous = false)
                 DEFAULT -> throw IllegalStateException("Preference value must be resolved: $preference")

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
@@ -12,6 +12,7 @@ import androidx.core.view.isVisible
 import androidx.viewpager.widget.ViewPager
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.download.DownloadManager
+import eu.kanade.tachiyomi.data.translation.TranslationManager
 import eu.kanade.tachiyomi.ui.reader.ReaderActivity
 import eu.kanade.tachiyomi.ui.reader.model.ChapterTransition
 import eu.kanade.tachiyomi.ui.reader.model.InsertPage
@@ -29,7 +30,7 @@ import kotlin.math.min
  * Implementation of a [Viewer] to display pages with a [ViewPager].
  */
 @Suppress("LeakingThis")
-abstract class PagerViewer(val activity: ReaderActivity) : Viewer {
+abstract class PagerViewer(val activity: ReaderActivity, val translationManager: TranslationManager) : Viewer {
 
     val downloadManager: DownloadManager by injectLazy()
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewerAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewerAdapter.kt
@@ -139,7 +139,7 @@ class PagerViewerAdapter(private val viewer: PagerViewer) : ViewPagerAdapter() {
      */
     override fun createView(container: ViewGroup, position: Int): View {
         return when (val item = items[position]) {
-            is ReaderPage -> PagerPageHolder(readerThemedContext, viewer, item)
+            is ReaderPage -> PagerPageHolder(readerThemedContext, viewer, item, viewer.translationManager)
             is ChapterTransition -> PagerTransitionHolder(readerThemedContext, viewer, item)
             else -> throw NotImplementedError("Holder for ${item.javaClass} not implemented")
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewers.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewers.kt
@@ -1,14 +1,15 @@
 package eu.kanade.tachiyomi.ui.reader.viewer.pager
 
+import eu.kanade.tachiyomi.data.translation.TranslationManager
 import eu.kanade.tachiyomi.ui.reader.ReaderActivity
 
 /**
  * Implementation of a left to right PagerViewer.
  */
-class L2RPagerViewer(activity: ReaderActivity) : PagerViewer(activity) {
+class L2RPagerViewer(activity: ReaderActivity, translationManager: TranslationManager) : PagerViewer(activity, translationManager) {
     /**
      * Creates a new left to right pager.
-     */
+     *//
     override fun createPager(): Pager {
         return Pager(activity)
     }
@@ -17,7 +18,7 @@ class L2RPagerViewer(activity: ReaderActivity) : PagerViewer(activity) {
 /**
  * Implementation of a right to left PagerViewer.
  */
-class R2LPagerViewer(activity: ReaderActivity) : PagerViewer(activity) {
+class R2LPagerViewer(activity: ReaderActivity, translationManager: TranslationManager) : PagerViewer(activity, translationManager) {
     /**
      * Creates a new right to left pager.
      */
@@ -43,7 +44,7 @@ class R2LPagerViewer(activity: ReaderActivity) : PagerViewer(activity) {
 /**
  * Implementation of a vertical (top to bottom) PagerViewer.
  */
-class VerticalPagerViewer(activity: ReaderActivity) : PagerViewer(activity) {
+class VerticalPagerViewer(activity: ReaderActivity, translationManager: TranslationManager) : PagerViewer(activity, translationManager) {
     /**
      * Creates a new vertical pager.
      */

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -194,6 +194,14 @@ class LibraryPreferences(
 
     fun disallowNonAsciiFilenames() = preferenceStore.getBoolean("disallow_non_ascii_filenames", false)
 
+    fun translateOnDownload() = preferenceStore.getBoolean("translate_on_download", false)
+
+    fun translateFrom() = preferenceStore.getString("translate_from", "en")
+
+    fun translateTo() = preferenceStore.getString("translate_to", "en")
+
+    fun translateEngine() = preferenceStore.getString("translate_engine", "ml-kit")
+
     // endregion
 
     enum class ChapterSwipeAction {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,6 @@
 [versions]
+mlkit_version = "17.0.3"
+mlkit_text_recognition_version = "16.0.1"
 aboutlib_version = "12.2.4"
 leakcanary = "2.14"
 moko = "0.25.1"
@@ -72,6 +74,12 @@ moko-core = { module = "dev.icerock.moko:resources", version.ref = "moko" }
 
 logcat = "com.squareup.logcat:logcat:0.4"
 
+mlkit-translate = { module = "com.google.mlkit:translate", version.ref = "mlkit_version" }
+mlkit-text-recognition = { module = "com.google.mlkit:text-recognition", version.ref = "mlkit_text_recognition_version" }
+mlkit-text-recognition-chinese = { module = "com.google.mlkit:text-recognition-chinese", version.ref = "mlkit_text_recognition_version" }
+mlkit-text-recognition-japanese = { module = "com.google.mlkit:text-recognition-japanese", version.ref = "mlkit_text_recognition_version" }
+mlkit-text-recognition-korean = { module = "com.google.mlkit:text-recognition-korean", version.ref = "mlkit_text_recognition_version" }
+
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase-bom" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
@@ -115,6 +123,7 @@ moko = { id = "dev.icerock.mobile.multiplatform-resources", version.ref = "moko"
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version = "3.0.6" }
 
 [bundles]
+mlkit = ["mlkit-translate", "mlkit-text-recognition", "mlkit-text-recognition-chinese", "mlkit-text-recognition-japanese", "mlkit-text-recognition-korean"]
 okhttp = ["okhttp-core", "okhttp-logging", "okhttp-brotli", "okhttp-dnsoverhttps"]
 js-engine = ["quickjs-android"]
 sqlite = ["sqlite-framework", "sqlite-ktx", "sqlite-android"]

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -435,6 +435,14 @@
     <string name="pref_read_with_long_tap">Show actions on long tap</string>
     <string name="pref_create_folder_per_manga">Save pages into separate folders</string>
     <string name="pref_create_folder_per_manga_summary">Creates folders according to entries\' title</string>
+
+    <string name="pref_category_translations">Translations</string>
+    <string name="pref_translations_summary">Translate, OCR</string>
+    <string name="pref_enable_translations">Translate after downloading</string>
+    <string name="pref_translate_from">Translate from</string>
+    <string name="pref_translate_to">Translate to</string>
+    <string name="pref_translate_engine">Translate model</string>
+
     <string name="pref_reader_theme">Background color</string>
     <string name="white_background">White</string>
     <string name="gray_background">Gray</string>
@@ -496,6 +504,7 @@
     <string name="pref_low">Low</string>
     <string name="pref_lowest">Lowest</string>
     <string name="pref_webtoon_disable_zoom_out">Disable zoom out</string>
+    <string name="pref_show_translations">Show translations</string>
 
       <!-- Downloads section -->
     <string name="pref_category_delete_chapters">Delete chapters</string>


### PR DESCRIPTION
This commit introduces a comprehensive translation feature to the application.

- Adds a new "Translations" section in the settings page, allowing users to configure translation preferences.
- Integrates ML Kit for on-device translation and OCR.
- Adds a translation icon to the chapter list for downloaded chapters.
- Implements a "Show Translations" checkbox in the reader controls.
- Displays translated text as an overlay on top of the comic images.

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
